### PR TITLE
Added support for the datepicker's "disabled" option

### DIFF
--- a/jquery-ui.multidatespicker.js
+++ b/jquery-ui.multidatespicker.js
@@ -122,7 +122,7 @@
 							? 'ui-state-highlight'
 							: '';
 							
-						var isDisabledDate = $this.multiDatesPicker('gotDate', date, 'disabled') !== false;
+						var isDisabledDate = ($this.multiDatesPicker('gotDate', date, 'disabled') !== false) || $this.datepicker('option', 'disabled');
 						var allSelected = this.multiDatesPicker.mode.options.maxPicks == $this.multiDatesPicker('getDates').length;
 						var selectable_date = (isDisabledDate || (allSelected && !highlight_class))
 							? false


### PR DESCRIPTION
This small addition allows the developer to temporarily disabled the multiDatesPicker by using the datepicker "disabled" option.
