### PR TITLE
Fix altFieldId

### DIFF
--- a/jquery-ui.multidatespicker.js
+++ b/jquery-ui.multidatespicker.js
@@ -139,7 +139,7 @@
 						var dateString = $this.multiDatesPicker('getDates', 'string');
 						
 						if (altFieldId != undefined && altFieldId != "") {
-							if($('*').find('#'+altFieldId).is('input, textarea')) {
+							if($('*').find(altFieldId).is('input, textarea')) {
 								$(altFieldId).val(dateString);
 							} else {
 								//$(altFieldId).empty().text(dateString); Original


### PR DESCRIPTION
multidatepicker doesn't update altField <input> with all selected dates because it fails to find given altFieldId. The error was a # symbol prepended to the altFieldIt. This commit fixes it.
