### PR TITLE
Allow selected dates to behave like they should with beforeShowDay

### DIFF
--- a/jquery-ui.multidatespicker.js
+++ b/jquery-ui.multidatespicker.js
@@ -159,7 +159,7 @@
 						if(this.multiDatesPicker.originalBeforeShowDay)
 							custom = this.multiDatesPicker.originalBeforeShowDay.call(this, date);
 						
-						var highlight_class = gotThisDate ? 'ui-state-highlight' : custom[1];
+						var highlight_class = gotThisDate ? 'ui-state-highlight ' + custom[1] : custom[1];
 						var selectable_date = !(isDisabledCalendar || isDisabledDate || (areAllSelected && !highlight_class));
 						return [selectable_date && custom[0], highlight_class];
 					},


### PR DESCRIPTION
Without this fix no matter what you do, selected dates will always only have the ui-state-highlight class.
