### PR TITLE
Fix for handling initial INPUT value

### DIFF
--- a/jquery-ui.multidatespicker.js
+++ b/jquery-ui.multidatespicker.js
@@ -191,10 +191,16 @@
 				} else {
 					$this.datepicker();
 				}
+
+        var old_value = $this.val();
 				
-				$this.datepicker('option', mdp_events);
+        $this.datepicker('option', mdp_events);
+
+        if (old_value !== undefined) {
+          methods.addDates.call(this, old_value.split(','));
+        }
 				
-				if(this.tagName == 'INPUT') $this.val($this.multiDatesPicker('getDates', 'string'));
+        if(this.tagName == 'INPUT') $this.val($this.multiDatesPicker('getDates', 'string'));
 				
 				// Fixes the altField filled with defaultDate by default
 				var altFieldOption = $this.datepicker('option', 'altField');


### PR DESCRIPTION
For some reason the call to jquery ui's init function seemed to be
emptying the INPUT field, and I also couldn't see a parser anywhere for
taking data already in the INPUT field.

I've written a rudamentary parser and triggered saving the INPUT field
value before the init on datepicker is called.
