### PR TITLE
Fix error when creating multiDatesPicker using ember

### DIFF
--- a/jquery-ui.multidatespicker.js
+++ b/jquery-ui.multidatespicker.js
@@ -278,13 +278,15 @@
 					case 'number':
 						var o_dates = new Array();
 						for(var i in this.multiDatesPicker.dates[type])
-							o_dates.push(
-								dateConvert.call(
-									this, 
-									this.multiDatesPicker.dates[type][i], 
-									format
-								)
-							);
+							if (this.multiDatesPicker.dates[type].hasOwnProperty(i)) {
+								o_dates.push(
+									dateConvert.call(
+										this, 
+										this.multiDatesPicker.dates[type][i], 
+										format
+									)
+								);
+							}
 						return o_dates;
 					
 					default: $.error('Format "'+format+'" not supported!');


### PR DESCRIPTION
I'm using ember, which extends the Array and Function properties, so they have a _super property also. This causes an error when trying to create any multiDatesPicker. To fix it, you need to iterate the dates[type] array using hasOwnProperty.

The error I get is:

Conversion from "function" format not allowed on jQuery.multiDatesPicker
