### PR TITLE
Loop values of of the array instead of all properties

### DIFF
--- a/jquery-ui.multidatespicker.js
+++ b/jquery-ui.multidatespicker.js
@@ -277,7 +277,7 @@
 					case 'string':
 					case 'number':
 						var o_dates = new Array();
-						for(var i in this.multiDatesPicker.dates[type])
+						for(var i = 0; i < this.multiDatesPicker.dates[type].length; i++)
 							o_dates.push(
 								dateConvert.call(
 									this, 


### PR DESCRIPTION
A few people got the error message "Conversion from 'string' format not allowed on jQuery.multiDatesPicker". This occurred because the 'for' loop injects all properties functions of the Array object instead of the values only.

Note that the log is also wrong as it displays the desired_format instead of the form_format that was equal to 'contains' function in my case. But this point is already fixed in another pull request.
