### PR TITLE
fix for 'Conversion from "string" format not allowed on jQuery.multiDatesPicker'

### DIFF
--- a/jquery-ui.multidatespicker.js
+++ b/jquery-ui.multidatespicker.js
@@ -277,14 +277,18 @@
 					case 'string':
 					case 'number':
 						var o_dates = new Array();
-						for(var i in this.multiDatesPicker.dates[type])
-							o_dates.push(
-								dateConvert.call(
-									this, 
-									this.multiDatesPicker.dates[type][i], 
-									format
-								)
-							);
+						for(var i in this.multiDatesPicker.dates[type]) {
+			              var current = this.multiDatesPicker.dates[type][i];
+
+			              if (current.hasOwnProperty(i))
+			                o_dates.push(
+			                  dateConvert.call(
+			                    this,
+			                    current,
+			                    format
+			                  )
+			                );
+						}
 						return o_dates;
 					
 					default: $.error('Format "'+format+'" not supported!');

--- a/jquery-ui.multidatespicker.js
+++ b/jquery-ui.multidatespicker.js
@@ -278,16 +278,16 @@
 					case 'number':
 						var o_dates = new Array();
 						for(var i in this.multiDatesPicker.dates[type]) {
-			              var current = this.multiDatesPicker.dates[type][i];
+							var current = this.multiDatesPicker.dates[type][i];
 
-			              if (current.hasOwnProperty(i))
-			                o_dates.push(
-			                  dateConvert.call(
-			                    this,
-			                    current,
-			                    format
-			                  )
-			                );
+							if (current.hasOwnProperty(i))
+							o_dates.push(
+								dateConvert.call(
+									this,
+									current,
+									format
+								)
+							);
 						}
 						return o_dates;
 					


### PR DESCRIPTION
should fix these types of errors:
https://github.com/dubrox/Multiple-Dates-Picker-for-jQuery-UI/issues/73
https://github.com/dubrox/Multiple-Dates-Picker-for-jQuery-UI/issues/20


they occur when something is added to Array.prototype