### PR TITLE
Prevent thrown error on _hideDatepicker()

### DIFF
--- a/jquery-ui.multidatespicker.js
+++ b/jquery-ui.multidatespicker.js
@@ -490,6 +490,7 @@
 	// allows MDP not to hide everytime a date is picked
 	$.multiDatesPicker._hideDatepicker = $.datepicker._hideDatepicker;
 	$.datepicker._hideDatepicker = function(){
+		if(!this._curInst) return; // Do not continue if this value is null, which would otherwie lead to a `Uncaught TypeError: Cannot read property 'input' of null`
 		var target = this._curInst.input[0];
 		var mdp = target.multiDatesPicker;
 		if(!mdp || (this._curInst.inline === false && !mdp.changed)) {


### PR DESCRIPTION
Fixes a possible thrown error: Uncaught TypeError: Cannot read property 'input' of null