### PR TITLE
Bump `jquery` & `jquery-ui` dependencies.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,8 +10,8 @@
     "jquery-ui.multidatespicker.css"
   ],
   "dependencies": {
-    "jquery": "1.9.1 - 3.2.x",
-    "jquery-ui": "1.7.0 - 1.12.x"
+    "jquery": "1.9.1 - 3.6.x",
+    "jquery-ui": "1.7.0 - 1.13.x"
   },
   "keywords": [
     "jquery",

--- a/package.json
+++ b/package.json
@@ -3,15 +3,15 @@
   "description": "Extension to the jQuery UI Calendar allowing multiple selections",
   "author": "Luca Lauretta <luca@lauretta.info>",
   "license": "(MIT OR GPLv2)",
-  "version": "1.6.6",
+  "version": "1.6.7",
   "main": "jquery-ui.multidatespicker.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/dubrox/Multiple-Dates-Picker-for-jQuery-UI.git"
   },
   "dependencies": {
-    "jquery": "1.9.1 - 3.2.x",
-    "jquery-ui": "1.7.0 - 1.12.x"
+    "jquery": "1.9.1 - 3.6.x",
+    "jquery-ui": "1.7.0 - 1.13.x"
   },
   "keywords": [
     "jquery",


### PR DESCRIPTION
Resolves [CVE-2022-31160](https://nvd.nist.gov/vuln/detail/CVE-2022-31160)